### PR TITLE
FIX: wrong formatting in One2many list datepicker

### DIFF
--- a/addons/po_persian_calendar/static/src/js/moment-jalaali.js
+++ b/addons/po_persian_calendar/static/src/js/moment-jalaali.js
@@ -908,7 +908,7 @@
 
       if (moment.isMoment(input)){
 
-        return moment.utc(input);
+        return makeMoment(moment.utc(input), null, lang, strict, true);
       }
 
       return makeMoment(input, format, lang, strict, true)


### PR DESCRIPTION
In One2many lists, the date formatting turns weird, after the date is picked:
![image](https://user-images.githubusercontent.com/6513072/129506898-768745ef-640f-45ab-9c31-edf7118b570c.png)
The `jMoment.utc` returns an original `moment` object rather that a `jmoment` object. This breaks the chain of `jmoment`s (at the end of the chain, to be specific).